### PR TITLE
Remove 'rails' from spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,7 @@
 # it.
 #
 require 'simplecov'
-SimpleCov.start 'rails'
+SimpleCov.start
 SimpleCov.add_filter %w[spec config app/jobs app/mailers app/channels]
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|


### PR DESCRIPTION
### What does this PR do?
Just changes the syntax of the simplecov gem in spec_helper to try and fix model coverage

### All tests passing?
- [x] Yes
- [ ] No

### SimpleCov 100%?
- [x] Yes
- [ ] No
- If No, what's missing:
Well, expect for the facades showing up in the model coverage. 

### Has this been tested on LOCALHOST?
- [x] Yes
- [ ] No
- Did something not work? If so, what was it?
